### PR TITLE
Changed factory dependency, fixed ram measuring, added isSemantic prop

### DIFF
--- a/Lab03/PatternExamples/Flyweight/Core/LightElementNode.cs
+++ b/Lab03/PatternExamples/Flyweight/Core/LightElementNode.cs
@@ -14,6 +14,8 @@
 
         public bool IsSelfClosing { get; set; }
 
+        public bool IsSemantic { get; set; }
+
         public List<string> CSSClassList { get; set; }
 
         public List<LightNode> Children { get; set; }
@@ -62,7 +64,7 @@
 
         protected virtual string GetHead()
         {
-            return $"<{TagName} class=\"{string.Join(' ', CSSClassList)}\">";
+            return $"<{(IsSemantic ? '!': ' ')}{TagName} class=\"{string.Join(' ', CSSClassList)}\">";
         }
 
         public override IEnumerable<string> GetLazyInnerHTML()

--- a/Lab03/PatternExamples/Flyweight/FlyweightVersion/LightElementNode_Flyweight.cs
+++ b/Lab03/PatternExamples/Flyweight/FlyweightVersion/LightElementNode_Flyweight.cs
@@ -6,34 +6,24 @@ namespace Flyweight.FlyweightVersion
     {
         public TagType TagType { get; set; }
 
-        public HashSet<string> CSSClassList { get; set; }
+        public List<string> CSSClassList { get; set; }
 
         public List<LightNode> Children { get; set; }
 
         public LightElementNode_Flyweight()
         {
             TagType = TagType.Undefined;
-            CSSClassList = new HashSet<string>();
+            CSSClassList = new();
             Children = new List<LightNode>();
         }
 
-        public LightElementNode_Flyweight(TagType tagType)
-        {
-            TagType = tagType;
-            CSSClassList = new();
-            Children = new();
-        }
+        public LightElementNode_Flyweight(TagType tagType) : this(tagType, new(), new()) { }
 
-        public LightElementNode_Flyweight(TagType tagType, List<string> cSSClassList)
-        {
-            TagType = tagType;
-            CSSClassList = new(cSSClassList);
-            Children = new();
-        }
+        public LightElementNode_Flyweight(TagType tagType, List<string> cSSClassList): this(tagType, cSSClassList, new()) { }
 
         public LightElementNode_Flyweight(TagType tagType, List<string> cSSClassList, List<LightNode> children)
         {
-            TagType = tagType;
+            TagType = TagTypeFactory.Instance.GetCached(tagType);
             CSSClassList = new(cSSClassList);
             Children = children;
         }
@@ -50,7 +40,7 @@ namespace Flyweight.FlyweightVersion
 
         protected virtual string GetHead()
         {
-            return $"<{TagType.TagName} class=\"{string.Join(' ', CSSClassList)}\">";
+            return $"<{(TagType.IsSemantic ? '!' : ' ')}{TagType.TagName} class=\"{string.Join(' ', CSSClassList)}\">";
         }
 
         public override IEnumerable<string> GetLazyInnerHTML()

--- a/Lab03/PatternExamples/Flyweight/FlyweightVersion/TagType.cs
+++ b/Lab03/PatternExamples/Flyweight/FlyweightVersion/TagType.cs
@@ -4,40 +4,37 @@
     {
         public static TagType Undefined = new();
 
-        private string _tagName = "";
-        public string TagName
-        {
-            get => _tagName;
-            set
-            {
-                _tagName = value.ToLower();
-            }
-        }
+        public readonly string TagName;
 
-        public bool IsSelfClosing { get; set; }
+        public readonly bool IsSelfClosing;
+
+        public readonly bool IsSemantic;
 
         public TagType()
         {
             TagName = "?";
             IsSelfClosing = false;
+            IsSemantic = false;
         }
 
-        public TagType(string tagName, bool isSelfClosing = false)
+        public TagType(string tagName, bool isSelfClosing = false, bool isSemantic = false)
         {
-            TagName = tagName;
+            TagName = tagName.ToLower();
             IsSelfClosing = isSelfClosing;
+            IsSemantic = isSemantic;
         }
 
         public string GetInfo()
         {
-            return $"Tag: {_tagName} - {(IsSelfClosing ? "Self-Closing" : "Not self-closing")}";
+            return $"Tag: {TagName} - {(IsSelfClosing ? "Self-Closing" : "Not self-closing")}, semantic - {IsSemantic}";
         }
 
         // especially for cache factory
         public override int GetHashCode()
         {
-            return _tagName.GetHashCode() * 17
-                ^ IsSelfClosing.GetHashCode() * 31;
+            return TagName.GetHashCode() * 17
+                ^ IsSelfClosing.GetHashCode() * 31
+                ^ IsSemantic.GetHashCode() * 37;
         }
 
         public override bool Equals(object? obj)
@@ -49,7 +46,8 @@
             var otherTag = (TagType)obj;
 
             return otherTag.IsSelfClosing == IsSelfClosing &&
-                otherTag._tagName == _tagName;
+                otherTag.TagName == TagName &&
+                otherTag.IsSemantic == IsSemantic;
         }
     }
 }

--- a/Lab03/PatternExamples/Flyweight/FlyweightVersion/TagTypeFactory.cs
+++ b/Lab03/PatternExamples/Flyweight/FlyweightVersion/TagTypeFactory.cs
@@ -5,11 +5,15 @@
     /// </summary>
     public class TagTypeFactory
     {
+        public static TagTypeFactory Instance => _lazyInstance.Value;
+
+        private static Lazy<TagTypeFactory> _lazyInstance = new(() => new TagTypeFactory());
+
         // how this works? TagType have overriden GetHashCode and Equals methods, that used inside dictionary.
         // when we have 2 TagTypes with the same properties, they will have the same hashcode, but different references.
         private Dictionary<TagType, TagType> _cachedTagTypes;
 
-        public TagTypeFactory()
+        private TagTypeFactory()
         {
             _cachedTagTypes = new();
         }

--- a/Lab03/PatternExamples/Flyweight/LightHTMLReaders/LightHTMLReader_Flyweight.cs
+++ b/Lab03/PatternExamples/Flyweight/LightHTMLReaders/LightHTMLReader_Flyweight.cs
@@ -5,18 +5,10 @@ namespace Flyweight.LightHTMLReaders
 {
     public class LightHTMLReader_Flyweight : ILightHTMLReader
     {
-        public TagTypeFactory TagTypeFactory { get; private set; }
-
-        public LightHTMLReader_Flyweight()
-        {
-            TagTypeFactory = new TagTypeFactory();
-        }
-
-
         public LightNode ReadLightHTML(string path)
         {
             using var sr = new StreamReader(path);
-            var root = new LightElementNode_Flyweight(TagTypeFactory.GetCached(new TagType("root")));
+            var root = new LightElementNode_Flyweight(new TagType("root"));
 
             bool firstLineReaded = false;
 
@@ -28,20 +20,20 @@ namespace Flyweight.LightHTMLReaders
                 LightElementNode_Flyweight node;
                 if (firstLineReaded == false)
                 {
-                    node = new LightElementNode_Flyweight(TagTypeFactory.GetCached(new TagType("h1")));
+                    node = new LightElementNode_Flyweight(new TagType("h1"));
                     firstLineReaded = true;
                 }
                 else if (line.Length < 20)
                 {
-                    node = new LightElementNode_Flyweight(TagTypeFactory.GetCached(new TagType("h2")));
+                    node = new LightElementNode_Flyweight(new TagType("h2"));
                 }
                 else if (line[0] == ' ')
                 {
-                    node = new LightElementNode_Flyweight(TagTypeFactory.GetCached(new TagType("blockquote")));
+                    node = new LightElementNode_Flyweight(new TagType("blockquote"));
                 }
                 else
                 {
-                    node = new LightElementNode_Flyweight(TagTypeFactory.GetCached(new TagType("p")));
+                    node = new LightElementNode_Flyweight(new TagType("p"));
 
                 }
 

--- a/Lab03/PatternExamples/Flyweight/Program.cs
+++ b/Lab03/PatternExamples/Flyweight/Program.cs
@@ -1,11 +1,16 @@
 ﻿using Flyweight.Core;
+using Flyweight.FlyweightVersion;
 using Flyweight.LightHTMLReaders;
 using System.Diagnostics;
 
 long GetRAM()
 {
-    Process currentProcess = System.Diagnostics.Process.GetCurrentProcess();
-    return currentProcess.WorkingSet64;
+    // gives allocated memory for all objects.
+    return GC.GetTotalMemory(true);
+
+    // gives current allocated memory for the process.
+    //Process currentProcess = System.Diagnostics.Process.GetCurrentProcess();
+    //return currentProcess.WorkingSet64;
 }
 
 void ShowLightHTMLPreview(LightNode lightNode, int lines = 5)
@@ -25,49 +30,41 @@ void ShowLightHTMLPreview(LightNode lightNode, int lines = 5)
     Console.WriteLine("...");
 }
 
+void MeasureLightHTMLRam(ILightHTMLReader lightHTMLReader, string path)
+{
+    long ramBefore = GetRAM();
+    var root = lightHTMLReader.ReadLightHTML(path);
+    long ramAfter = GetRAM();
+    long used = ramAfter - ramBefore;
+
+    Console.WriteLine($"Used RAM: {used}");
+
+    Console.WriteLine("LightNode preview:");
+    ShowLightHTMLPreview(root);
+}
+
 string bookPath = "./book.txt";
 
 var task1 = new Task(() =>
 {
     Console.WriteLine("Without flyweight pattern");
-    // test without flyweight pattern.
-    long ramBefore = GetRAM();
-    var htmlReader = new LightHTMLReader();
-    var root = htmlReader.ReadLightHTML(bookPath);
-    long ramAfter = GetRAM();
 
-    long used = ramAfter - ramBefore;
-    Console.WriteLine($"USED RAM: {used}"); 
-    Console.WriteLine("\nPreview: ");
-
-    ShowLightHTMLPreview(root);
-
-    // around 2.7 mb
+    // around 1.57 mb
+    MeasureLightHTMLRam(new LightHTMLReader(), bookPath);
 });
 
 var task2 = new Task(() =>
 {
     Console.WriteLine("Using flyweight pattern:");
+    
+    // around 1.53 mb
+    MeasureLightHTMLRam(new LightHTMLReader_Flyweight(), bookPath);
 
-    // flyweight pattern
-    long ramBefore = GetRAM();
-    var htmlReader = new LightHTMLReader_Flyweight();
-    var root = htmlReader.ReadLightHTML(bookPath);
-    long ramAfter = GetRAM();
-
-    long used = ramAfter - ramBefore;
-
-    Console.WriteLine($"Count of cached elements: {htmlReader.TagTypeFactory.CountOfCachedTags}");
-    foreach (var tagType in htmlReader.TagTypeFactory.GetCachedTags())
+    Console.WriteLine($"Count of cached elements: {TagTypeFactory.Instance.CountOfCachedTags}");
+    foreach (var tagType in TagTypeFactory.Instance.GetCachedTags())
     {
         Console.WriteLine(tagType.GetInfo());
     }
-
-    // around 1 mb
-    Console.WriteLine($"USED RAM: {used}");
-    Console.WriteLine("\nPreview: ");
-    ShowLightHTMLPreview(root);
-
 });
 
 task1.Start();
@@ -77,3 +74,12 @@ Console.WriteLine("\n--------------------------------------------------");
 
 task2.Start();
 task2.Wait();
+
+/* In conclusion, we don't achieve massive memory boost, because Flyweight becomes in hand when object have many different properties.
+ * In this case, we have tag name, tag enclosing type and IsSemantic property. Most valuable property is name,
+ * because it string type, but most of the tags contains only 1-2 characters (1-2 bytes). Boolean is one byte. In all objects properties take 4-6 bytes.
+ * Count of generated objects around 5k, when we move intristic state to another class, we decrease memory usage at most 30k (6bytes * 5k) bytes.
+ * As we can see from results.
+ * 
+ * Before flyweight (1.57mb) -> After flyweight (1.53mb)
+ */


### PR DESCRIPTION
Now LightHTMLNode_Flyweight manages TagTypeFactory. Added property to the LightHTMLNode (isSemantic). Maked more clear example with RAM usage.